### PR TITLE
Refond l’interface du calculateur d’expédition

### DIFF
--- a/pages_streamlit/calcul_expedition.py
+++ b/pages_streamlit/calcul_expedition.py
@@ -19,16 +19,102 @@ PALIERS_EXPEDITION = [
 ]
 
 DICT_MAX_METAL = {
-    '<10k': 40000,
-    '<100k': 500000,
-    '<1M': 1200000,
-    '<5M': 1800000,
-    '<25M': 2400000,
-    '<50M': 3000000,
-    '<75M': 3600000,
-    '<100M': 4200000,
-    '>100M': 5000000,
+    '<10k': 40_000,
+    '<100k': 500_000,
+    '<1M': 1_200_000,
+    '<5M': 1_800_000,
+    '<25M': 2_400_000,
+    '<50M': 3_000_000,
+    '<75M': 3_600_000,
+    '<100M': 4_200_000,
+    '>100M': 5_000_000,
 }
+
+VAISSEAUX = [
+    'Chasseur Léger',
+    'Chasseur Lourd',
+    'Croiseur',
+    'Vaisseau de bataille',
+    'Traqueur',
+    'Bombardier',
+    'Destructeur',
+    'Etoile de la mort',
+    'Faucheur',
+    'Eclaireur',
+    'Petit transporteur',
+    'Grand transporteur',
+    'Vaisseau de colonisation',
+    'Recycleur',
+    'Sonde',
+]
+
+COUT_METAL = [
+    3_000, 6_000, 20_000, 45_000, 30_000, 50_000, 60_000, 5_000_000,
+    85_000, 8_000, 2_000, 6_000, 10_000, 10_000, 0,
+]
+COUT_CRISTAL = [
+    1_000, 4_000, 7_000, 15_000, 40_000, 25_000, 50_000, 4_000_000,
+    55_000, 15_000, 2_000, 6_000, 20_000, 6_000, 1_000,
+]
+COUT_DEUT = [
+    0, 0, 2_000, 0, 15_000, 15_000, 15_000, 1_000_000,
+    20_000, 8_000, 0, 0, 10_000, 2_000, 0,
+]
+FRET_BASE = [
+    50, 100, 800, 1_500, 750, 500, 2_000, 1_000_000,
+    10_000, 10_000, 5_000, 25_000, 7_500, 20_000, 5,
+]
+
+RECUPERABLE_SI_PRESENT = {
+    'Chasseur Léger': [
+        'Chasseur Léger', 'Chasseur Lourd', 'Croiseur', 'Vaisseau de bataille',
+        'Traqueur', 'Bombardier', 'Destructeur', 'Faucheur', 'Eclaireur',
+        'Petit transporteur', 'Grand transporteur',
+    ],
+    'Chasseur Lourd': [
+        'Chasseur Lourd', 'Croiseur', 'Vaisseau de bataille', 'Traqueur',
+        'Bombardier', 'Destructeur', 'Faucheur', 'Eclaireur',
+        'Grand transporteur',
+    ],
+    'Croiseur': [
+        'Chasseur Lourd', 'Croiseur', 'Vaisseau de bataille', 'Traqueur',
+        'Bombardier', 'Destructeur', 'Faucheur', 'Eclaireur',
+    ],
+    'Vaisseau de bataille': [
+        'Vaisseau de bataille', 'Traqueur', 'Bombardier', 'Destructeur',
+        'Faucheur', 'Eclaireur',
+    ],
+    'Traqueur': [
+        'Vaisseau de bataille', 'Traqueur', 'Bombardier', 'Destructeur',
+        'Faucheur',
+    ],
+    'Bombardier': ['Traqueur', 'Bombardier', 'Destructeur', 'Faucheur'],
+    'Destructeur': ['Bombardier', 'Destructeur', 'Faucheur'],
+    'Faucheur': ['Destructeur', 'Faucheur'],
+    'Eclaireur': [
+        'Croiseur', 'Vaisseau de bataille', 'Traqueur', 'Bombardier',
+        'Destructeur', 'Faucheur', 'Eclaireur',
+    ],
+    'Petit transporteur': [
+        'Chasseur Léger', 'Chasseur Lourd', 'Croiseur', 'Vaisseau de bataille',
+        'Traqueur', 'Bombardier', 'Destructeur', 'Faucheur', 'Eclaireur',
+        'Petit transporteur', 'Grand transporteur', 'Sonde',
+    ],
+    'Sonde': [
+        'Chasseur Léger', 'Chasseur Lourd', 'Croiseur', 'Vaisseau de bataille',
+        'Traqueur', 'Bombardier', 'Destructeur', 'Faucheur', 'Eclaireur',
+        'Petit transporteur', 'Grand transporteur', 'Sonde',
+    ],
+    'Grand transporteur': [
+        'Chasseur Léger', 'Chasseur Lourd', 'Croiseur', 'Vaisseau de bataille',
+        'Traqueur', 'Bombardier', 'Destructeur', 'Faucheur', 'Eclaireur',
+        'Grand transporteur',
+    ],
+}
+
+
+def mise_en_forme_number(number):
+    return f'{int(number):,}'.replace(',', ' ')
 
 
 def get_palier_expedition(points_top_1):
@@ -39,320 +125,508 @@ def get_palier_expedition(points_top_1):
     return len(PALIERS_EXPEDITION) - 1, PALIERS_EXPEDITION[-1][1]
 
 
+def creer_table_flotte():
+    return pd.DataFrame({
+        'Vaisseau': VAISSEAUX,
+        'Quantité': np.zeros(len(VAISSEAUX), dtype=np.int64),
+    })
+
+
+def calculer_expedition(
+    palier,
+    flotte,
+    vitesse_eco,
+    tech_hyperespace,
+    classe_explorateur,
+    bonus_res,
+    bonus_vdx,
+    bonus_fret_fdv,
+    bonus_n3,
+    taux_ferrailleur,
+):
+    quantites = flotte.set_index('Vaisseau')['Quantité'].astype(int)
+    facteur_classe = 1.5 if classe_explorateur else 1
+    facteur_eclaireur = 2 if quantites.get('Eclaireur', 0) > 0 else 1
+
+    max_metal = int(
+        DICT_MAX_METAL[palier]
+        * vitesse_eco
+        * facteur_classe
+        * facteur_eclaireur
+    )
+    max_cristal = int(max_metal / 2)
+    max_deut = int(max_metal / 3)
+
+    df_res = pd.DataFrame(
+        [max_metal, max_cristal, max_deut],
+        index=['Metal', 'Cristal', 'Deut'],
+        columns=['Ressources'],
+    )
+    df_res['Forme de vie'] = np.int64(df_res['Ressources'] * bonus_res)
+    df_res['Forme de Vie N3'] = np.int64(
+        (df_res['Ressources'] + df_res['Forme de vie']) * bonus_n3
+    )
+    df_res['Total'] = (
+        df_res['Ressources']
+        + df_res['Forme de vie']
+        + df_res['Forme de Vie N3']
+    )
+
+    df_expe = pd.DataFrame({'Nombre': quantites.reindex(VAISSEAUX, fill_value=0)})
+    df_expe['Recuperable'] = 'Non'
+
+    for vaisseau_cible, vaisseaux_requis in RECUPERABLE_SI_PRESENT.items():
+        if df_expe.loc[vaisseaux_requis, 'Nombre'].sum() > 0:
+            df_expe.loc[vaisseau_cible, 'Recuperable'] = 'Oui'
+
+    df_expe['cout_metal'] = COUT_METAL
+    df_expe['cout_cristal'] = COUT_CRISTAL
+    df_expe['cout_deut'] = COUT_DEUT
+    df_expe['Structure'] = df_expe['cout_metal'] + df_expe['cout_cristal']
+
+    bonus_fret_hyperespace = tech_hyperespace * 0.05
+    df_expe['fret'] = np.array(FRET_BASE, dtype=float)
+    df_expe['fret'] *= 1 + bonus_fret_hyperespace
+    df_expe['fret'] *= 1 + bonus_fret_fdv
+    df_expe['fret_dispo'] = df_expe['Nombre'] * df_expe['fret']
+
+    fret_dispo = df_expe['fret_dispo'].sum()
+    max_metal_with_fdv = df_res.loc['Metal', 'Total']
+
+    # Le comportement historique est conservé : si le fret est insuffisant,
+    # la valeur affichée est le fret réellement disponible et la différence
+    # reste négative par rapport au maximum récupérable.
+    if max_metal < fret_dispo:
+        montant_max = max_metal_with_fdv
+        montant_max_vsx = max_metal
+    else:
+        montant_max = fret_dispo
+        montant_max_vsx = fret_dispo
+
+    df_expe['Vaisseau récupérable'] = np.where(
+        df_expe['Recuperable'] == 'Oui',
+        np.floor(montant_max_vsx / df_expe['Structure']),
+        0,
+    ).astype(int)
+    df_expe['Forme de vie'] = np.int64(
+        np.floor(df_expe['Vaisseau récupérable'] * bonus_vdx)
+    )
+    df_expe['Forme de vie N3'] = np.int64(
+        np.floor(df_expe['Vaisseau récupérable'] * bonus_vdx * bonus_n3)
+    )
+    df_expe['Total'] = np.int64(
+        df_expe['Vaisseau récupérable']
+        + df_expe['Forme de vie']
+        + df_expe['Forme de vie N3']
+    )
+
+    df_expe['metal_total'] = (
+        df_expe['cout_metal'] * df_expe['Total'] * (taux_ferrailleur / 100)
+    )
+    df_expe['cristal_total'] = (
+        df_expe['cout_cristal'] * df_expe['Total'] * (taux_ferrailleur / 100)
+    )
+    df_expe['deut_total'] = (
+        df_expe['cout_deut'] * df_expe['Total'] * (taux_ferrailleur / 100)
+    )
+
+    cargo_optimal = {
+        'PT': int(np.ceil(max_metal_with_fdv / df_expe.loc['Petit transporteur', 'fret'])),
+        'GT': int(np.ceil(max_metal_with_fdv / df_expe.loc['Grand transporteur', 'fret'])),
+        'Eclaireur': int(np.ceil(max_metal_with_fdv / df_expe.loc['Eclaireur', 'fret'])),
+    }
+
+    return {
+        'palier': palier,
+        'df_res': df_res,
+        'df_expe': df_expe,
+        'fret_dispo': fret_dispo,
+        'montant_max': montant_max,
+        'max_metal_with_fdv': max_metal_with_fdv,
+        'metal_collectable': montant_max - max_metal_with_fdv,
+        'cristal_collectable': montant_max / 2 - max_metal_with_fdv / 2,
+        'deut_collectable': montant_max / 3 - max_metal_with_fdv / 3,
+        'cargo_optimal': cargo_optimal,
+    }
+
+
+def creer_figure_vaisseaux(df_expe):
+    df_affiche = df_expe[df_expe['Vaisseau récupérable'] > 0]
+    fig = go.Figure()
+    fig.add_bar(
+        x=df_affiche.index,
+        y=df_affiche['Vaisseau récupérable'],
+        name='Vaisseaux récupérables',
+        marker_color='#0000CC',
+    )
+    fig.add_bar(
+        x=df_affiche.index,
+        y=df_affiche['Forme de vie'],
+        name='Bonus Forme de vie',
+        marker_color='#00BFFF',
+    )
+    fig.add_bar(
+        x=df_affiche.index,
+        y=df_affiche['Forme de vie N3'],
+        name='Bonus Forme de vie N3',
+        marker_color='#B0C4DE',
+    )
+    fig.update_layout(
+        title='Quantité de vaisseaux récupérables',
+        barmode='stack',
+        bargap=0.15,
+        legend_title_text='',
+        xaxis_title='',
+        yaxis_title='Quantité',
+    )
+    return fig
+
+
+def creer_figure_ressources(df_expe):
+    return go.Figure(
+        data=[
+            go.Pie(
+                labels=['Métal', 'Cristal', 'Deutérium'],
+                values=[
+                    df_expe['metal_total'].sum(),
+                    df_expe['cristal_total'].sum(),
+                    df_expe['deut_total'].sum(),
+                ],
+            )
+        ],
+        layout=go.Layout(title='Vaisseaux convertis en ressources'),
+    )
+
+
+def afficher_resultat(resultat):
+    montant_max = resultat['montant_max']
+
+    st.subheader(f"Résultat — palier {resultat['palier']}")
+    kpi_metal, kpi_cristal, kpi_deut = st.columns(3)
+    with kpi_metal:
+        st.metric(
+            'Métal collectable',
+            mise_en_forme_number(montant_max),
+            mise_en_forme_number(resultat['metal_collectable']),
+        )
+    with kpi_cristal:
+        st.metric(
+            'Cristal collectable',
+            mise_en_forme_number(montant_max / 2),
+            mise_en_forme_number(resultat['cristal_collectable']),
+        )
+    with kpi_deut:
+        st.metric(
+            'Deutérium collectable',
+            mise_en_forme_number(montant_max / 3),
+            mise_en_forme_number(resultat['deut_collectable']),
+        )
+
+    if resultat['metal_collectable'] < 0:
+        st.caption(
+            'La différence négative correspond aux ressources non récupérables '
+            'avec le fret actuellement disponible.'
+        )
+
+    st.subheader('Fret optimal')
+    cargo_dispo, cargo_pt, cargo_gt, cargo_eclaireur = st.columns(4)
+    with cargo_dispo:
+        st.metric('Cargo disponible', mise_en_forme_number(resultat['fret_dispo']))
+    with cargo_pt:
+        st.metric(
+            'Cargo optimal PT',
+            f"{mise_en_forme_number(resultat['cargo_optimal']['PT'])} vaisseaux",
+        )
+    with cargo_gt:
+        st.metric(
+            'Cargo optimal GT',
+            f"{mise_en_forme_number(resultat['cargo_optimal']['GT'])} vaisseaux",
+        )
+    with cargo_eclaireur:
+        st.metric(
+            'Cargo optimal Éclaireur',
+            f"{mise_en_forme_number(resultat['cargo_optimal']['Eclaireur'])} vaisseaux",
+        )
+
+    tab_vaisseaux, tab_ressources, tab_details = st.tabs(
+        ['Vaisseaux récupérables', 'Ressources', 'Détails du calcul']
+    )
+
+    with tab_vaisseaux:
+        colonne_tableau, colonne_graphique = st.columns([1.1, 1])
+        with colonne_tableau:
+            df_expe_format = resultat['df_expe'][[
+                'Recuperable',
+                'Vaisseau récupérable',
+                'Forme de vie',
+                'Forme de vie N3',
+                'Total',
+            ]].copy()
+            for colonne in [
+                'Vaisseau récupérable',
+                'Forme de vie',
+                'Forme de vie N3',
+                'Total',
+            ]:
+                df_expe_format[colonne] = df_expe_format[colonne].map(
+                    mise_en_forme_number
+                )
+            st.dataframe(df_expe_format, width='stretch', height=560)
+        with colonne_graphique:
+            st.plotly_chart(
+                creer_figure_vaisseaux(resultat['df_expe']),
+                width='stretch',
+            )
+
+    with tab_ressources:
+        colonne_tableau, colonne_graphique = st.columns([1.1, 1])
+        with colonne_tableau:
+            df_expe_copy = resultat['df_expe'].copy()
+            df_expe_copy.loc['Total'] = df_expe_copy.sum(numeric_only=True)
+            for colonne in ['Total', 'metal_total', 'cristal_total', 'deut_total']:
+                df_expe_copy[colonne] = df_expe_copy[colonne].map(
+                    mise_en_forme_number
+                )
+            st.dataframe(
+                df_expe_copy[['Total', 'metal_total', 'cristal_total', 'deut_total']],
+                width='stretch',
+                height=605,
+            )
+        with colonne_graphique:
+            st.plotly_chart(
+                creer_figure_ressources(resultat['df_expe']),
+                width='stretch',
+            )
+
+    with tab_details:
+        st.write('Ressources maximales avant limitation par le fret')
+        df_res_format = resultat['df_res'].copy()
+        for colonne in ['Ressources', 'Forme de vie', 'Forme de Vie N3', 'Total']:
+            df_res_format[colonne] = df_res_format[colonne].map(
+                mise_en_forme_number
+            )
+        st.dataframe(df_res_format, width='stretch')
+
+
+def afficher_comparaison(resultat_actuel, resultat_suivant):
+    st.subheader('Comparaison des paliers')
+    comparaison = pd.DataFrame(
+        {
+            'Indicateur': [
+                'Métal maximal',
+                'Cristal maximal',
+                'Deutérium maximal',
+                'Cargo optimal PT',
+                'Cargo optimal GT',
+                'Cargo optimal Éclaireur',
+            ],
+            f"Palier actuel ({resultat_actuel['palier']})": [
+                resultat_actuel['max_metal_with_fdv'],
+                resultat_actuel['max_metal_with_fdv'] / 2,
+                resultat_actuel['max_metal_with_fdv'] / 3,
+                resultat_actuel['cargo_optimal']['PT'],
+                resultat_actuel['cargo_optimal']['GT'],
+                resultat_actuel['cargo_optimal']['Eclaireur'],
+            ],
+            f"Palier suivant ({resultat_suivant['palier']})": [
+                resultat_suivant['max_metal_with_fdv'],
+                resultat_suivant['max_metal_with_fdv'] / 2,
+                resultat_suivant['max_metal_with_fdv'] / 3,
+                resultat_suivant['cargo_optimal']['PT'],
+                resultat_suivant['cargo_optimal']['GT'],
+                resultat_suivant['cargo_optimal']['Eclaireur'],
+            ],
+        }
+    )
+    comparaison['Différence'] = (
+        comparaison.iloc[:, 2] - comparaison.iloc[:, 1]
+    )
+    for colonne in comparaison.columns[1:]:
+        comparaison[colonne] = comparaison[colonne].map(mise_en_forme_number)
+    st.dataframe(comparaison, hide_index=True, width='stretch')
+
+    tab_actuel, tab_suivant = st.tabs([
+        f"Palier actuel ({resultat_actuel['palier']})",
+        f"Palier suivant ({resultat_suivant['palier']})",
+    ])
+    with tab_actuel:
+        afficher_resultat(resultat_actuel)
+    with tab_suivant:
+        afficher_resultat(resultat_suivant)
+
+
 def calcul_expe():
-    
-    style_metric_cards(background_color='#03152A', border_color='#0083B9', border_left_color='#0083B9', border_size_px=1, box_shadow=False, border_radius_px=0)
-    
-    def mise_en_forme_number(number, type='int'):
-        if type == 'int':
-            new_number = "{:,}".format(int(number)).replace(',', ' ').replace('.', ',')
-        elif type == 'float':
-            new_number = "{:,}".format(number).replace(',', ' ').replace('.', ',')
-        return new_number 
-    
-    with st.form('Calcul expedition'):
-        st.subheader('Univers & Compte')
+    style_metric_cards(
+        background_color='#03152A',
+        border_color='#0083B9',
+        border_left_color='#0083B9',
+        border_size_px=1,
+        box_shadow=False,
+        border_radius_px=0,
+    )
 
-        palier_actuel_index, palier_actuel = get_palier_expedition(st.session_state['top1'])
-        paliers_disponibles = [palier_actuel]
+    points_top_1 = st.session_state['top1']
+    palier_actuel_index, palier_actuel = get_palier_expedition(points_top_1)
+    palier_suivant = None
+    points_avant_palier = None
 
-        if palier_actuel_index < len(PALIERS_EXPEDITION) - 1:
-            paliers_disponibles.append(PALIERS_EXPEDITION[palier_actuel_index + 1][1])
+    if palier_actuel_index < len(PALIERS_EXPEDITION) - 1:
+        palier_suivant = PALIERS_EXPEDITION[palier_actuel_index + 1][1]
+        limite_actuelle = PALIERS_EXPEDITION[palier_actuel_index][0]
+        points_avant_palier = max(0, int(limite_actuelle - points_top_1))
 
-        st.markdown(
-            f'Palier actuel : **{palier_actuel}** || '
-            f'(Points du top 1 : **{mise_en_forme_number(st.session_state["top1"])}**)'
+    st.header('Calculateur d’expédition')
+    resume_top, resume_actuel, resume_suivant = st.columns(3)
+    with resume_top:
+        st.metric('Points du top 1', mise_en_forme_number(points_top_1))
+    with resume_actuel:
+        st.metric('Palier actuel', palier_actuel)
+    with resume_suivant:
+        if palier_suivant is None:
+            st.metric('Prochain palier', 'Palier maximal atteint')
+        else:
+            st.metric(
+                'Prochain palier',
+                palier_suivant,
+                f'{mise_en_forme_number(points_avant_palier)} points restants',
+                delta_color='off',
+            )
+
+    marge_gauche, contenu, marge_droite = st.columns([1, 6, 1])
+    with contenu:
+        with st.form('Calcul expedition', border=False):
+            comparer_palier_suivant = st.toggle(
+                'Comparer avec le palier suivant',
+                value=False,
+                disabled=palier_suivant is None,
+                help=(
+                    'Le calcul utilise toujours le palier actuel par défaut. '
+                    'Activez cette option pour afficher simultanément le palier suivant.'
+                ),
+            )
+
+            colonne_parametres, colonne_fdv = st.columns(2, gap='large')
+
+            with colonne_parametres:
+                with st.container(border=True):
+                    st.subheader('Paramètres principaux')
+                    tech_hyperespace = st.slider(
+                        'Technologie Hyperespace', 0, 30, 1
+                    )
+                    classe_explorateur = st.checkbox('Classe Explorateur')
+                    taux_ferrailleur = st.slider(
+                        'Taux Ferrailleur (%)',
+                        min_value=35,
+                        max_value=100,
+                        value=100,
+                        help=(
+                            'Impacte les ressources récupérées lorsque les '
+                            'vaisseaux sont envoyés au ferrailleur.'
+                        ),
+                    )
+
+            with colonne_fdv:
+                with st.expander('Bonus de forme de vie', expanded=True):
+                    fdv_gauche, fdv_droite = st.columns(2)
+                    with fdv_gauche:
+                        bonus_res = st.number_input(
+                            'Bonus ressources (%)',
+                            min_value=0.0,
+                            value=0.0,
+                            format='%.2f',
+                        )
+                        bonus_vdx = st.number_input(
+                            'Bonus vaisseaux (%)',
+                            min_value=0.0,
+                            value=0.0,
+                            format='%.2f',
+                        )
+                        bonus_am = st.number_input(
+                            'Bonus antimatière (%)',
+                            min_value=0.0,
+                            value=0.0,
+                            format='%.2f',
+                            help='Conservé pour les évolutions futures du calculateur.',
+                        )
+                    with fdv_droite:
+                        bonus_fret_fdv = st.number_input(
+                            'Bonus fret (%)',
+                            min_value=0.0,
+                            value=0.0,
+                            format='%.2f',
+                        )
+                        bonus_n3 = st.number_input(
+                            'Bonus Tech Explorateur 3_6 (%)',
+                            min_value=0.0,
+                            value=0.0,
+                            format='%.2f',
+                            help='Saisissez 0 si la classe Explorateur n’est pas active.',
+                        )
+
+            st.subheader('Flotte envoyée')
+            flotte = st.data_editor(
+                creer_table_flotte(),
+                hide_index=True,
+                width='stretch',
+                height=570,
+                disabled=['Vaisseau'],
+                column_config={
+                    'Vaisseau': st.column_config.TextColumn(
+                        'Vaisseau',
+                        width='large',
+                    ),
+                    'Quantité': st.column_config.NumberColumn(
+                        'Quantité',
+                        min_value=0,
+                        step=1,
+                        format='%d',
+                        width='small',
+                    ),
+                },
+                key='flotte_expedition',
+            )
+
+            submitted = st.form_submit_button(
+                'Calculer l’expédition',
+                type='primary',
+                width='stretch',
+            )
+
+    if not submitted:
+        return
+
+    flotte['Quantité'] = (
+        pd.to_numeric(flotte['Quantité'], errors='coerce')
+        .fillna(0)
+        .clip(lower=0)
+        .astype(int)
+    )
+
+    parametres_communs = {
+        'flotte': flotte,
+        'vitesse_eco': st.session_state['vitesse_eco'],
+        'tech_hyperespace': tech_hyperespace,
+        'classe_explorateur': classe_explorateur,
+        'bonus_res': bonus_res / 100,
+        'bonus_vdx': bonus_vdx / 100,
+        'bonus_fret_fdv': bonus_fret_fdv / 100,
+        'bonus_n3': bonus_n3 / 100,
+        'taux_ferrailleur': taux_ferrailleur,
+    }
+
+    # Le bonus antimatière n'entre pas encore dans les résultats affichés.
+    _ = bonus_am
+
+    resultat_actuel = calculer_expedition(
+        palier=palier_actuel,
+        **parametres_communs,
+    )
+
+    if comparer_palier_suivant and palier_suivant is not None:
+        resultat_suivant = calculer_expedition(
+            palier=palier_suivant,
+            **parametres_communs,
         )
-
-        points_top_1 = st.radio(
-            'Palier utilisé pour le calcul',
-            paliers_disponibles,
-            index=0,
-            horizontal=True,
-            format_func=lambda palier: (
-                f'Palier actuel ({palier})'
-                if palier == palier_actuel
-                else f'Palier suivant ({palier})'
-            ),
-            help='Le palier actuel reste sélectionné par défaut. Le palier suivant permet de simuler la progression du top 1.',
-        )
-
-        tech_hyperespace = st.slider('Technologie Hyperespace', 0, 30, 1)
-        bonus_fret = tech_hyperespace * 0.05
-        
-        st.subheader('Classe')
-        # Explorateur ?
-        classe = st.checkbox('Classe Explorateur')
-        if classe:
-            classe_facteur = 1.5
-        else:
-            classe_facteur = 1
-            
-        
-            
-        st.subheader('Forme de vie')
-
-        
-        bonus_res = st.number_input('Bonus ressources en %', 0.0, value=0.0, format='%.2f', help="10.2% s'écrit 10.2")
-        bonus_vdx = st.number_input('Bonus vaisseaux en %', 0.0, value=0.0, format='%.2f', help="10.2% s'écrit 10.2")
-        bonus_am = st.number_input('Bonus AM en %', 0.0, value=0.0, format='%.2f',help="10.2% s'écrit 10.2")
-        bonus_fret_fdv = st.number_input('Bonus fret en %', 0.0, value=0.0, format='%.2f', help="10.2% s'écrit 10.2")
-        bonus_n3 = st.number_input('Bonus Tech Explorateur 3_6', 0.0, value=0.0, format='%.2f', help="0 si pas classe Explorateur")
-
-        
-        bonus_res = bonus_res / 100
-        bonus_vdx = bonus_vdx / 100
-        bonus_am = bonus_am / 100
-        bonus_fret_fdv = bonus_fret_fdv / 100
-        bonus_n3 = bonus_n3 / 100
-        
-        st.subheader('Flotte')
-        
-        cle = st.number_input('Chasseur léger', 0, value=0)
-        chlo = st.number_input('Chasseur lourd', 0, value=0)
-        cro = st.number_input('Croiseur', 0, value=0)
-        vb = st.number_input('Vaisseau de bataille', 0, value=0)
-        traq = st.number_input('Traqueur', 0, value=0)
-        bb = st.number_input('Bombardier', 0, value=0)
-        destro = st.number_input('Destructeur', 0, value=0)
-        edlm = st.number_input('Etoile de la mort', 0, value=0)
-        faucheur = st.number_input('Faucheur', 0, value=0)
-        eclaireur = st.number_input('Eclaireur', 0, value=0)
-        pt = st.number_input('Petit transporteur', 0, value=0)
-        gt = st.number_input('Grand transporteur', 0, value=0)
-        vc = st.number_input('Vaisseau de colonisation', 0, value=0)
-        recycleur = st.number_input('Recycleur', 0, value=0)
-        sonde = st.number_input('Sonde', 0, value=0)
-        
-        st.subheader('Paramètres supplémentaires')
-        
-        taux_ferrailleur = st.slider('Taux Ferrailleur (%)', min_value=35, max_value=100, value=100, help='Ce paramètre impacte le tableau Ressources (vaisseaux), vous permettant de savoir les ressources collectables via le ferrailleur.')
-        
-        submitted = st.form_submit_button('Valider')
-        
-    if submitted:
-        
-        # calcul res max
-        
-        if eclaireur > 0:
-            facteur_eclaireur = 2
-        else:
-            facteur_eclaireur = 1
-        
-        max_metal = int(DICT_MAX_METAL[points_top_1] * st.session_state["vitesse_eco"] * classe_facteur * facteur_eclaireur)
-        max_cristal = int(max_metal / 2)
-        max_deut = int(max_metal / 3)
-        
-        df_res = pd.DataFrame([max_metal, max_cristal, max_deut], index=['Metal', 'Cristal', 'Deut'], columns=['Ressources'])
-        df_res['Forme de vie'] = np.int64(df_res['Ressources'] * bonus_res)
-        df_res['Forme de Vie N3'] = np.int64((df_res['Ressources'] + df_res['Forme de vie']) * bonus_n3)
-        df_res['Total'] = df_res['Ressources'] + df_res['Forme de vie'] + df_res['Forme de Vie N3']
-        
-        # calcul vaisseau
-        
-        df_expe = pd.DataFrame([cle, chlo, cro, vb, traq, bb, destro, edlm, faucheur, eclaireur, pt, gt, vc, recycleur, sonde], columns=['Nombre'])
-        df_expe.index=['Chasseur Léger', 'Chasseur Lourd', 'Croiseur', 'Vaisseau de bataille', 'Traqueur',
-                                        'Bombardier', 'Destructeur', 'Etoile de la mort', 'Faucheur', 'Eclaireur',
-                                        'Petit transporteur', 'Grand transporteur', 'Vaisseau de colonisation', 'Recycleur', 'Sonde']
-        
-        df_expe['Recuperable'] = 'Non'
-        
-        def vsx_recup(nombre_sum, vsx_target):
-            if df_expe.loc[nombre_sum]['Nombre'].sum() > 0:
-                for vsx in vsx_target:
-                    df_expe.loc[vsx, 'Recuperable'] = 'Oui'
-                
-        vsx_recup(['Chasseur Léger', 'Chasseur Lourd', 'Croiseur', 'Vaisseau de bataille', 'Traqueur', 
-                  'Bombardier', 'Destructeur', 'Faucheur', 'Eclaireur', 'Petit transporteur', 'Grand transporteur'], ['Chasseur Léger'])
-        vsx_recup(['Chasseur Lourd', 'Croiseur', 'Vaisseau de bataille', 'Traqueur', 
-                  'Bombardier', 'Destructeur', 'Faucheur', 'Eclaireur', 'Grand transporteur'], ['Chasseur Lourd']) 
-        vsx_recup(['Chasseur Lourd', 'Croiseur', 'Vaisseau de bataille', 'Traqueur', 
-                  'Bombardier', 'Destructeur', 'Faucheur', 'Eclaireur'], ['Croiseur']) 
-        vsx_recup(['Vaisseau de bataille', 'Traqueur', 
-                  'Bombardier', 'Destructeur', 'Faucheur', 'Eclaireur'], ['Vaisseau de bataille'])
-        vsx_recup(['Vaisseau de bataille', 'Traqueur', 
-                  'Bombardier', 'Destructeur', 'Faucheur'], ['Traqueur'])
-        vsx_recup(['Traqueur', 'Bombardier', 'Destructeur', 'Faucheur'], ['Bombardier'])
-        vsx_recup(['Bombardier', 'Destructeur', 'Faucheur'], ['Destructeur'])
-        vsx_recup(['Destructeur', 'Faucheur'], ['Faucheur'])   
-        vsx_recup(['Croiseur', 'Vaisseau de bataille', 'Traqueur', 
-                  'Bombardier', 'Destructeur', 'Faucheur', 'Eclaireur'], ['Eclaireur'])
-        vsx_recup(['Chasseur Léger', 'Chasseur Lourd', 'Croiseur', 'Vaisseau de bataille', 'Traqueur', 
-                  'Bombardier', 'Destructeur', 'Faucheur', 'Eclaireur', 'Petit transporteur', 'Grand transporteur', 'Sonde'], ['Petit transporteur', 'Sonde'])
-        vsx_recup(['Chasseur Léger', 'Chasseur Lourd', 'Croiseur', 'Vaisseau de bataille', 'Traqueur', 
-                  'Bombardier', 'Destructeur', 'Faucheur', 'Eclaireur', 'Grand transporteur'], ['Grand transporteur'])
-        
-        df_expe['cout_metal'] = [3000, 6000, 20000, 45000, 30000, 50000, 60000, 5000000, 85000, 8000, 2000, 6000, 10000, 10000, 0]
-        df_expe['cout_cristal'] = [1000, 4000, 7000, 15000, 40000, 25000, 50000, 4000000, 55000, 15000, 2000, 6000, 20000, 6000, 1000]
-        df_expe['cout_deut'] = [0, 0, 2000, 0, 15000, 15000, 15000, 1000000, 20000, 8000, 0, 0, 10000, 2000, 0]          
-        df_expe['Structure'] = df_expe['cout_metal'] + df_expe['cout_cristal']
-        
-        df_expe['fret'] = [50, 100, 800, 1500, 750, 500, 2000, 1000000, 10000, 10000, 5000, 25000, 7500, 20000, 5]
-        df_expe['fret'] = df_expe['fret'] * (1 + bonus_fret)
-        df_expe['fret'] = df_expe['fret'] * (1 + bonus_fret_fdv)
-        
-        df_expe['fret_dispo'] = df_expe['Nombre'] * df_expe['fret']
-        fret_dispo = df_expe['fret_dispo'].sum()
-        
-        max_metal_with_fdv = df_res.loc['Metal', 'Total']
-        
-        if max_metal < fret_dispo:
-            montant_max = max_metal_with_fdv
-            montant_max_vsx = max_metal
-        else:
-            montant_max = fret_dispo
-            montant_max_vsx = fret_dispo
-            
-
-        df_expe['Vaisseau récupérable'] = 0
-        
-        df_expe['Vaisseau récupérable'] = np.where(df_expe['Recuperable'] == 'Oui',
-                                                   np.floor(montant_max_vsx / df_expe['Structure']),
-                                                   df_expe['Vaisseau récupérable'])
-        
-        df_expe['Vaisseau récupérable'] = df_expe['Vaisseau récupérable'].astype('int')
-    
-        
-        df_expe['Forme de vie'] = np.int64(
-            np.floor(df_expe['Vaisseau récupérable'] * bonus_vdx))
-        
-        df_expe['Forme de vie N3'] = np.int64(
-            np.floor(df_expe['Vaisseau récupérable'] * bonus_vdx * bonus_n3))
-        
-        df_expe['Total'] = np.int64(df_expe['Vaisseau récupérable'] + df_expe['Forme de vie'] + df_expe['Forme de vie N3'])
-        
-        
-
-        
-        fig = go.Figure()
-        i = 0
-        for vsx in ['Chasseur Léger', 'Chasseur Lourd', 'Croiseur', 'Vaisseau de bataille', 'Traqueur',
-                                        'Bombardier', 'Destructeur', 'Etoile de la mort', 'Faucheur', 'Eclaireur',
-                                        'Petit transporteur', 'Grand transporteur', 'Vaisseau de colonisation', 'Recycleur']:
-            
-            if i == 0:
-                showlegend = True
-            else:
-                showlegend = False
-            
-            if df_expe.loc[vsx, 'Vaisseau récupérable'] > 0:
-                fig.add_trace(go.Histogram(histfunc='sum',
-                x=[vsx],
-                y=[df_expe.loc[vsx, 'Total']],
-                name='Vaisseaux récupérables',
-                texttemplate="%{y}",
-                marker_color = '#0000CC',
-                showlegend=showlegend))
-
-                fig.add_trace(go.Histogram(histfunc='sum',
-                        x=[vsx],
-                        y=[df_expe.loc[vsx, 'Forme de vie']],
-                        name="Dont Bonus Forme de vie",
-                        texttemplate="%{y}",
-                        marker_color = '#00BFFF',
-                        showlegend=showlegend))
-                
-
-                fig.add_trace(go.Histogram(histfunc='sum',
-                        x=[vsx],
-                        y=[df_expe.loc[vsx, 'Forme de vie N3']],
-                        name="Dont Bonus Forme de vie N3",
-                        texttemplate="%{y}",
-                        marker_color = '#B0C4DE',
-                        showlegend=showlegend))
-                
-                i += 1
-
-        fig.update_layout(
-            title='Quantité de vaisseaux',
-            barmode="overlay",
-            bargap=0.1)
-        
-        
-        tab1, tab2 = st.tabs(['Vaisseaux', 'Ressources'])
-        
-        with tab1:
-        
-            st.subheader('Vaisseaux')
-            vsx1, vsx2 = st.columns(2)
-            
-            with vsx1:
-                df_expe_format = df_expe[['Recuperable', 'Vaisseau récupérable', 'Forme de vie', 'Forme de vie N3', 'Total']].copy()
-                
-                for col in ['Vaisseau récupérable', 'Forme de vie', 'Forme de vie N3', 'Total']:
-                    df_expe_format[col] = df_expe_format[col].apply(lambda x : mise_en_forme_number(x))
-                st.dataframe(df_expe_format, use_container_width=True, height=560)
-            with vsx2:
-                st.plotly_chart(fig)
-        
-        
-            st.subheader('Ressources (vaisseaux)')
-            
-            df_expe['metal_total'] = (df_expe['cout_metal'] * df_expe['Total']) *(taux_ferrailleur / 100)
-            df_expe['cristal_total'] = (df_expe['cout_cristal'] * df_expe['Total']) *(taux_ferrailleur / 100)
-            df_expe['deut_total'] = (df_expe['cout_deut'] * df_expe['Total']) *(taux_ferrailleur / 100)
-            vsx3, vsx4 = st.columns(2)
-        
-            with vsx3:
-                df_expe_copy = df_expe.copy()
-                df_expe_copy.loc['Total'] = df_expe_copy.sum(axis=0)
-                for col in ['Total', 'metal_total', 'cristal_total', 'deut_total']:
-                    df_expe_copy[col] = df_expe_copy[col].apply(lambda x : mise_en_forme_number(x))
-                st.dataframe(df_expe_copy[['Total', 'metal_total', 'cristal_total', 'deut_total']], use_container_width=True, height=605)
-            with vsx4:
-                
-                fig_ressource = go.Figure(data=[go.Pie(labels=['metal', 'cristal', 'deut'], values=[df_expe['metal_total'].sum(),
-                                                                                                    df_expe['cristal_total'].sum(),
-                                                                                                    df_expe['deut_total'].sum()])])
-                fig_ressource.update_layout(
-                title='Quantité de vaisseaux sous forme de ressources')              
-                
-                st.plotly_chart(fig_ressource)
-        
-        # Ressources
-        
-        with tab2:
-        
-            st.write('Ressources maximales')
-            
-            for col in ['Ressources', 'Forme de vie', 'Total']:
-                df_res[col] = df_res[col].apply(lambda x : mise_en_forme_number(x))
-            st.dataframe(df_res)
-            
-            metal_collectable = montant_max - max_metal_with_fdv
-            cristal_collectable = montant_max/2 - max_metal_with_fdv/2
-            deut_collectable = montant_max/3 - max_metal_with_fdv/3
-            
-            cargo_opti_gt = np.ceil(max_metal_with_fdv / df_expe.loc['Grand transporteur', 'fret'])
-            cargo_opti_pt = np.ceil(max_metal_with_fdv / df_expe.loc['Petit transporteur', 'fret'])
-            cargo_opti_eclaireur = np.ceil(max_metal_with_fdv / df_expe.loc['Eclaireur', 'fret'])
-            
-            
-            carg1, carg2, carg3, carg4 = st.columns(4)
-            
-    
-            
-            with carg1:
-                # st.metric('Cargo disponible', int(fret_dispo))
-                st.metric('Cargo disponible', mise_en_forme_number(fret_dispo))
-            with carg2:
-                st.metric('Cargo optimal PT',f'{mise_en_forme_number(cargo_opti_pt)} vaisseaux')
-            with carg3:
-                st.metric('Cargo optimal GT',f'{mise_en_forme_number(cargo_opti_gt)} vaisseaux')
-            with carg4:
-                st.metric('Cargo optimal Eclaireur',f'{mise_en_forme_number(cargo_opti_eclaireur)} vaisseaux')
-                
-            
-            
-            kpi1, kpi2, kpi3 = st.columns(3)
-            
-            with kpi1:
-                st.metric('Metal collectable', mise_en_forme_number(montant_max), mise_en_forme_number(metal_collectable))
-            with kpi2:
-                st.metric('Cristal collectable', mise_en_forme_number(montant_max/2), mise_en_forme_number(cristal_collectable))
-            with kpi3:
-                st.metric('Deut collectable', mise_en_forme_number(montant_max/3), mise_en_forme_number(deut_collectable))
-        
-        
-
-    
+        afficher_comparaison(resultat_actuel, resultat_suivant)
+    else:
+        afficher_resultat(resultat_actuel)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit==1.22.0
+streamlit==1.59.0
 pandas
 numpy
 asyncio


### PR DESCRIPTION
## Ce qui change

- remplace la longue suite de champs de flotte par un tableau éditable compact ;
- regroupe les paramètres principaux et les bonus de forme de vie sur deux colonnes ;
- laisse la section **Bonus de forme de vie ouverte par défaut** ;
- conserve le palier actuel comme calcul par défaut et permet une comparaison simultanée avec le palier suivant ;
- affiche en tête les points du top 1, le palier actuel, le prochain palier et les points restants ;
- ajoute une section **Fret optimal** comprenant le cargo disponible et le nombre optimal de PT, GT et Éclaireurs ;
- conserve la différence négative actuelle lorsque le cargo disponible est inférieur au maximum récupérable ;
- réorganise les résultats en KPI et onglets pour les vaisseaux, les ressources et le détail du calcul ;
- passe Streamlit de `1.22.0` à `1.59.0` pour utiliser les composants modernes de mise en page et `st.data_editor`.

## Validation

- compilation Python du module ;
- tests des bornes de paliers, notamment 10 k et 100 M ;
- test du calcul avec fret insuffisant et vérification de la différence négative ;
- vérification du calcul des cargos optimaux PT, GT et Éclaireur.
